### PR TITLE
Merge test environment additions into development

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,16 @@
+// src/App.tsx
+
+import React from "react";
+import Router from "./router/MainRouter";
+import EnvironmentLabel from "./components/global/EnvironmentLabel";
+
+const App: React.FC = () => {
+  return (
+    <>
+      <EnvironmentLabel />
+      <Router />
+    </>
+  );
+};
+
+export default App;

--- a/src/components/case-components/AddAnswer.tsx
+++ b/src/components/case-components/AddAnswer.tsx
@@ -169,6 +169,7 @@ const AddAnswer: React.FC<AddAnswerProps> = ({
               maxLength={ANSWER_CONTENT.MAX}
               minLength={ANSWER_CONTENT.MIN}
               wrapperClassName="transition-colors duration-150 h-36"
+              height="36"
             />
           </div>
           {/* File attachment component */}

--- a/src/components/case-components/CaseInfo.tsx
+++ b/src/components/case-components/CaseInfo.tsx
@@ -162,7 +162,7 @@ const CaseInfo: React.FC<ICaseInfoProps> = ({
                     >
                       <button
                         type="button"
-                        title="Edit case"
+                        title="Редактирай сигнала"
                         className="p-1 rounded text-gray-500 hover:text-blue-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-400 hover:cursor-pointer"
                       >
                         <PencilSquareIcon className="h-5 w-5" />

--- a/src/components/global/EnvironmentLabel.tsx
+++ b/src/components/global/EnvironmentLabel.tsx
@@ -1,0 +1,21 @@
+// src/components/global/EnvironmentLabel.tsx
+
+import React from "react";
+
+const EnvironmentLabel: React.FC = () => {
+  // Компонентът се показва само ако променливата на средата е "development"
+  if (import.meta.env.VITE_APP_ENV !== "development") {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed top-0 left-2/5 -translate-x-1/2 bg-blue-600 text-white text-md font-bold px-4 py-1 rounded-b-lg shadow-lg z-[9999]"
+      title="Вие сте на версия, предвидена за тестване"
+    >
+      ТЕСТОВА СРЕДА
+    </div>
+  );
+};
+
+export default EnvironmentLabel;

--- a/src/components/global/EnvironmentLabel.tsx
+++ b/src/components/global/EnvironmentLabel.tsx
@@ -10,7 +10,7 @@ const EnvironmentLabel: React.FC = () => {
 
   return (
     <div
-      className="fixed top-0 left-2/5 -translate-x-1/2 bg-blue-600 text-white text-md font-bold px-4 py-1 rounded-b-lg shadow-lg z-[9999]"
+      className="fixed top-0 left-12 bg-blue-600 text-white text-sm font-bold px-2 py-0 rounded-b-lg shadow-lg z-[9999]"
       title="Вие сте на версия, предвидена за тестване"
     >
       ТЕСТОВА СРЕДА

--- a/src/components/modals/ContentDialog.tsx
+++ b/src/components/modals/ContentDialog.tsx
@@ -53,6 +53,7 @@ const ContentDialog: React.FC<ContentDialogProps> = ({
         <button
           className="hidden lg:flex p-1.5 rounded-md text-gray-500 hover:text-blue-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 transition hover:cursor-pointer"
           type="button"
+          title="Отвори сигнала на цял екран"
           aria-label={t("showFullScreen") || "Show full screen"}
         >
           <ArrowTopRightOnSquareIcon className="h-5 w-5" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,11 @@
+// src/main.tsx
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "./i18n"; // Import the i18n configuration
-import "./index.css"; // Your global styles
-import Router from "./router/MainRouter";
+import "./i18n";
+import "./index.css";
+// import Router from "./router/MainRouter"; // <- Вече не импортираме Router директно
+import App from "./App"; // <-- Импортираме новия App компонент
 import { ApolloProvider } from "@apollo/client";
 import { apolloClient } from "./graphql/client";
 import { ToastContainer } from "react-toastify";
@@ -11,7 +14,7 @@ createRoot(document.getElementById("root")!).render(
   <ApolloProvider client={apolloClient}>
     <StrictMode>
       <ToastContainer />
-      <Router />
+      <App /> {/* <-- Използваме App вместо Router */}
     </StrictMode>
   </ApolloProvider>
 );


### PR DESCRIPTION
Added:
- Test environment visual through .env.local: VITE_APP_ENV="development" # used to display the testing environment label for the testing environment to avoid confusion
- Proper overflow styling for the Simplified text editor (sticky header, scroll)
- added some missing titles in CaseInfo
